### PR TITLE
Add events data model and favorites UI

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,4 +1,40 @@
-const routes = new Set(["home", "events", "calendar", "admin"]);
+import eventsSchema from "./media/schemas/events.schema.json" assert { type: "json" };
+import newsSchema from "./media/schemas/news.schema.json" assert { type: "json" };
+import { parseISODate, formatDateTime, isToday, isThisWeek, compareAsc } from "./app/utils/date.js";
+import { createSkeletonList } from "./app/components/Skeleton.js";
+import { createEventCard } from "./app/components/EventCard.js";
+import { getFavorites, toggleFavorite, onFavoritesChange } from "./app/state/favorites.js";
+
+const ROUTES = new Set(["home", "events", "calendar", "admin"]);
+const DATA_ENDPOINTS = {
+  events: "./data/events.sample.json",
+  news: "./data/news.sample.json"
+};
+
+const EVENT_TABS = [
+  {
+    id: "today",
+    label: "Heute",
+    filter: (event) => isToday(parseISODate(event.startsAt))
+  },
+  {
+    id: "week",
+    label: "Diese Woche",
+    filter: (event) => {
+      const date = parseISODate(event.startsAt);
+      return !isToday(date) && isThisWeek(date);
+    }
+  },
+  {
+    id: "upcoming",
+    label: "Bald",
+    filter: (event) => {
+      const date = parseISODate(event.startsAt);
+      return date && date > endOfWeek();
+    }
+  }
+];
+
 const main = document.getElementById("app");
 const yearEl = document.getElementById("year");
 const navButtons = document.querySelectorAll(".nav-list [data-route]");
@@ -40,10 +76,11 @@ window.addEventListener("load", () => {
   renderRoute(initialRoute);
   yearEl.textContent = new Date().getFullYear();
   registerServiceWorker();
+  bootstrapEventsSection();
 });
 
 function renderRoute(route) {
-  const targetRoute = routes.has(route) ? route : "home";
+  const targetRoute = ROUTES.has(route) ? route : "home";
   document.title = `Community Hub — ${targetRoute.charAt(0).toUpperCase()}${targetRoute.slice(1)}`;
   const views = document.querySelectorAll(".view");
   views.forEach((section) => {
@@ -70,6 +107,359 @@ function renderRoute(route) {
   if (window.location.hash.replace("#", "") !== targetRoute) {
     window.location.hash = targetRoute;
   }
+}
+
+function bootstrapEventsSection() {
+  const eventsSection = document.querySelector('[data-view="events"]');
+  if (!eventsSection) return;
+
+  const contentContainer = document.createElement("div");
+  contentContainer.className = "events-layout";
+  contentContainer.setAttribute("role", "region");
+  contentContainer.setAttribute("aria-live", "polite");
+  eventsSection.replaceChildren(createEventsHeader(), contentContainer);
+
+  const tablist = document.createElement("div");
+  tablist.className = "tablist";
+  tablist.setAttribute("role", "tablist");
+  tablist.setAttribute("aria-label", "Event-Zeiträume");
+
+  EVENT_TABS.forEach((tab, index) => {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "tab-button";
+    button.textContent = tab.label;
+    button.id = `events-tab-${tab.id}`;
+    button.setAttribute("role", "tab");
+    button.setAttribute("data-tab", tab.id);
+    button.setAttribute("aria-selected", String(index === 0));
+    button.setAttribute("tabindex", index === 0 ? "0" : "-1");
+    button.addEventListener("click", () => activateTab(tab.id));
+    button.addEventListener("keydown", (event) => handleTabKeydown(event, tab.id));
+    tablist.appendChild(button);
+  });
+
+  const favoritesToggle = document.createElement("button");
+  favoritesToggle.type = "button";
+  favoritesToggle.className = "favorites-filter";
+  favoritesToggle.textContent = "Nur Favoriten";
+  favoritesToggle.setAttribute("aria-pressed", "false");
+  favoritesToggle.addEventListener("click", () => {
+    const pressed = favoritesToggle.getAttribute("aria-pressed") === "true";
+    favoritesToggle.setAttribute("aria-pressed", String(!pressed));
+    renderEvents(currentEvents, { force: true });
+  });
+
+  const tabsWrapper = document.createElement("div");
+  tabsWrapper.className = "tabs-wrapper";
+  tabsWrapper.append(tablist, favoritesToggle);
+
+  contentContainer.appendChild(tabsWrapper);
+
+  const panelsContainer = document.createElement("div");
+  panelsContainer.className = "tab-panels";
+  EVENT_TABS.forEach((tab, index) => {
+    const panel = document.createElement("div");
+    panel.id = `events-panel-${tab.id}`;
+    panel.setAttribute("role", "tabpanel");
+    panel.setAttribute("aria-labelledby", `events-tab-${tab.id}`);
+    panel.hidden = index !== 0;
+    panel.setAttribute("tabindex", "-1");
+    panel.dataset.tabPanel = tab.id;
+    panel.appendChild(createSkeletonList({ count: 3, variant: "event" }));
+    panelsContainer.appendChild(panel);
+  });
+
+  contentContainer.appendChild(panelsContainer);
+
+  let currentEvents = [];
+  const offlineNotice = createOfflineNotice();
+  contentContainer.appendChild(offlineNotice);
+
+  const cache = new Map();
+
+  const loadData = async () => {
+    const cacheKey = "events";
+    let fromCache = false;
+
+    try {
+      const cached = cache.get(cacheKey);
+      if (cached) {
+        currentEvents = cached;
+        renderEvents(cached);
+        fromCache = true;
+      }
+
+      const { data, stale } = await fetchWithCache(DATA_ENDPOINTS.events, {
+        cacheKey,
+        cache
+      });
+      currentEvents = data;
+      renderEvents(data, { force: stale });
+      toggleOfflineNotice(false);
+    } catch (error) {
+      console.error("Events konnten nicht geladen werden", error);
+      toggleOfflineNotice(!navigator.onLine);
+      showErrorOverlay(error, { context: "Events laden" });
+      if (!fromCache) {
+        renderEmptyState();
+      }
+    }
+  };
+
+  loadData();
+
+  window.addEventListener("online", () => {
+    toggleOfflineNotice(false);
+    loadData();
+  });
+
+  window.addEventListener("offline", () => {
+    toggleOfflineNotice(true);
+  });
+
+  onFavoritesChange(() => renderEvents(currentEvents, { force: true }));
+
+  function createEventsHeader() {
+    const header = document.createElement("header");
+    header.className = "events-header";
+
+    const heading = document.createElement("h2");
+    heading.textContent = "Kommende Events";
+    heading.id = "events-heading";
+
+    const description = document.createElement("p");
+    description.className = "section-description";
+    description.textContent =
+      "Behalte die nächsten Community-Termine im Blick und markiere deine Favoriten.";
+
+    header.append(heading, description);
+    return header;
+  }
+
+  function activateTab(tabId) {
+    const buttons = tablist.querySelectorAll("[role='tab']");
+    const panels = panelsContainer.querySelectorAll("[role='tabpanel']");
+    buttons.forEach((btn) => {
+      const isActive = btn.dataset.tab === tabId;
+      btn.setAttribute("aria-selected", String(isActive));
+      btn.setAttribute("tabindex", isActive ? "0" : "-1");
+    });
+    panels.forEach((panel) => {
+      const isActive = panel.dataset.tabPanel === tabId;
+      panel.hidden = !isActive;
+      if (isActive) {
+        requestAnimationFrame(() => panel.focus());
+      }
+    });
+    renderEvents(currentEvents, { force: true });
+  }
+
+  function handleTabKeydown(event, tabId) {
+    const buttons = [...tablist.querySelectorAll("[role='tab']")];
+    const currentIndex = buttons.findIndex((btn) => btn.dataset.tab === tabId);
+    if (event.key === "ArrowRight" || event.key === "ArrowDown") {
+      event.preventDefault();
+      const nextIndex = (currentIndex + 1) % buttons.length;
+      buttons[nextIndex].click();
+      buttons[nextIndex].focus();
+    } else if (event.key === "ArrowLeft" || event.key === "ArrowUp") {
+      event.preventDefault();
+      const prevIndex = (currentIndex - 1 + buttons.length) % buttons.length;
+      buttons[prevIndex].click();
+      buttons[prevIndex].focus();
+    } else if (event.key === "Home") {
+      event.preventDefault();
+      buttons[0].click();
+      buttons[0].focus();
+    } else if (event.key === "End") {
+      event.preventDefault();
+      buttons[buttons.length - 1].click();
+      buttons[buttons.length - 1].focus();
+    }
+  }
+
+  function renderEvents(events, { force = false } = {}) {
+    if (!Array.isArray(events) || events.length === 0) {
+      renderEmptyState();
+      return;
+    }
+
+    const favoritesSet = getFavorites();
+    const favoritesOnly = contentContainer
+      .querySelector(".favorites-filter")
+      ?.getAttribute("aria-pressed") === "true";
+
+    EVENT_TABS.forEach((tab) => {
+      const panel = panelsContainer.querySelector(`[data-tab-panel='${tab.id}']`);
+      if (!panel) return;
+
+      const filtered = events
+        .filter((event) => isValidEvent(event))
+        .filter((event) => (favoritesOnly ? favoritesSet.has(event.id) : true))
+        .filter(tab.filter)
+        .sort((a, b) => compareAsc(parseISODate(a.startsAt), parseISODate(b.startsAt)));
+
+      const renderedIds = JSON.stringify(filtered.map((event) => event.id));
+      if (!force && panel.dataset.rendered === renderedIds) {
+        return;
+      }
+
+      panel.dataset.rendered = renderedIds;
+      panel.replaceChildren();
+
+      if (filtered.length === 0) {
+        const empty = document.createElement("p");
+        empty.className = "empty-state";
+        empty.textContent = favoritesOnly
+          ? "Keine Favoriten in diesem Zeitraum."
+          : "Keine Events in diesem Zeitraum geplant.";
+        panel.appendChild(empty);
+        return;
+      }
+
+      const list = document.createElement("ul");
+      list.className = "event-list";
+      list.setAttribute("role", "list");
+
+      filtered.forEach((event) => {
+        const card = createEventCard({
+          event,
+          onToggleFavorite: () => toggleFavorite(event.id),
+          favorite: favoritesSet.has(event.id),
+          formatDate: formatDateTime
+        });
+        list.appendChild(card);
+      });
+
+      panel.appendChild(list);
+    });
+  }
+
+  function renderEmptyState() {
+    EVENT_TABS.forEach((tab) => {
+      const panel = panelsContainer.querySelector(`[data-tab-panel='${tab.id}']`);
+      if (!panel) return;
+      panel.replaceChildren(createSkeletonList({ count: 3, variant: "event" }));
+      delete panel.dataset.rendered;
+    });
+  }
+
+  function toggleOfflineNotice(visible) {
+    offlineNotice.hidden = !visible;
+  }
+
+  function createOfflineNotice() {
+    const banner = document.createElement("div");
+    banner.className = "offline-banner";
+    banner.hidden = true;
+    banner.setAttribute("role", "status");
+    banner.textContent = "Offline: Zeige zuletzt gespeicherte Daten.";
+    return banner;
+  }
+}
+
+async function fetchWithCache(url, { cacheKey, signal, cache }) {
+  const cacheStore = cache instanceof Map ? cache : new Map();
+  const mergedSignal = mergeSignals([signal]);
+  let stale = false;
+
+  try {
+    if (cacheStore.has(cacheKey)) {
+      stale = true;
+    }
+
+    const response = await fetch(url, { cache: "no-cache", signal: mergedSignal });
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status} beim Laden von ${url}`);
+    }
+
+    const json = await response.json();
+    validateData(url.includes("events") ? "events" : "news", json);
+    cacheStore.set(cacheKey, json);
+    return { data: json, stale };
+  } catch (error) {
+    if (cacheStore.has(cacheKey)) {
+      return { data: cacheStore.get(cacheKey), stale: true };
+    }
+    throw error;
+  }
+}
+
+function mergeSignals(signals) {
+  const filtered = signals.filter(Boolean);
+  if (filtered.length === 0) return undefined;
+  const controller = new AbortController();
+  filtered.forEach((signal) => {
+    if (signal.aborted) {
+      controller.abort(signal.reason);
+    } else {
+      signal.addEventListener(
+        "abort",
+        () => {
+          controller.abort(signal.reason);
+        },
+        { once: true }
+      );
+    }
+  });
+  return controller.signal;
+}
+
+function validateData(type, data) {
+  const schema = type === "events" ? eventsSchema : newsSchema;
+  if (!schema?.items) {
+    throw new Error(`Kein Schema für ${type} hinterlegt`);
+  }
+  if (!Array.isArray(data)) {
+    throw new Error(`Erwartete Array-Daten für ${type}`);
+  }
+  data.forEach((item, index) => {
+    const errors = validateAgainstSchema(schema.items, item);
+    if (errors.length > 0) {
+      const error = new Error(`Schema-Fehler in ${type}[${index}]: ${errors.join(", ")}`);
+      error.source = type;
+      error.index = index;
+      throw error;
+    }
+  });
+}
+
+function validateAgainstSchema(schema, item) {
+  const errors = [];
+  const { properties = {}, required = [] } = schema;
+  required.forEach((field) => {
+    if (!(field in item)) {
+      errors.push(`Feld ${field} fehlt`);
+    }
+  });
+  Object.entries(properties).forEach(([key, definition]) => {
+    const value = item[key];
+    if (value === undefined || value === null) return;
+    if (definition.type === "string" && typeof value !== "string") {
+      errors.push(`Feld ${key} muss string sein`);
+    }
+    if (definition.type === "boolean" && typeof value !== "boolean") {
+      errors.push(`Feld ${key} muss boolean sein`);
+    }
+    if (definition.type === "array") {
+      if (!Array.isArray(value)) {
+        errors.push(`Feld ${key} muss array sein`);
+      } else if (definition.items?.type === "string" && value.some((entry) => typeof entry !== "string")) {
+        errors.push(`Feld ${key} darf nur Strings enthalten`);
+      }
+    }
+    if (definition.format === "date-time" && !isISODateTime(value)) {
+      errors.push(`Feld ${key} muss ISO-8601 UTC sein`);
+    }
+  });
+  return errors;
+}
+
+function isISODateTime(value) {
+  if (typeof value !== "string") return false;
+  const isoPattern = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{3})?Z$/;
+  return isoPattern.test(value);
 }
 
 function applyTheme(theme, { updateStorage } = { updateStorage: true }) {
@@ -106,4 +496,77 @@ function registerServiceWorker() {
         console.error("Service Worker registration failed", error);
       });
   }
+}
+
+function showErrorOverlay(error, { context } = {}) {
+  const existing = document.querySelector(".error-overlay");
+  if (existing) {
+    existing.remove();
+  }
+  const overlay = document.createElement("div");
+  overlay.className = "error-overlay";
+  overlay.setAttribute("role", "alert");
+  overlay.setAttribute("aria-live", "assertive");
+
+  const heading = document.createElement("h3");
+  heading.textContent = "Es ist ein Fehler aufgetreten";
+
+  const message = document.createElement("p");
+  message.textContent = error.message || String(error);
+
+  const metaList = document.createElement("dl");
+  metaList.className = "error-meta";
+
+  if (context) {
+    const dt = document.createElement("dt");
+    dt.textContent = "Kontext";
+    const dd = document.createElement("dd");
+    dd.textContent = context;
+    metaList.append(dt, dd);
+  }
+
+  if (error.source) {
+    const dt = document.createElement("dt");
+    dt.textContent = "Quelle";
+    const dd = document.createElement("dd");
+    dd.textContent = error.source;
+    metaList.append(dt, dd);
+  }
+
+  if (error.line || error.lineno) {
+    const dt = document.createElement("dt");
+    dt.textContent = "Zeile";
+    const dd = document.createElement("dd");
+    dd.textContent = error.line || error.lineno;
+    metaList.append(dt, dd);
+  }
+
+  const closeButton = document.createElement("button");
+  closeButton.type = "button";
+  closeButton.className = "error-close";
+  closeButton.textContent = "Schließen";
+  closeButton.addEventListener("click", () => overlay.remove());
+
+  overlay.append(heading, message, metaList, closeButton);
+
+  document.body.appendChild(overlay);
+}
+
+function endOfWeek(baseDate = new Date()) {
+  const date = new Date(
+    Date.UTC(baseDate.getUTCFullYear(), baseDate.getUTCMonth(), baseDate.getUTCDate())
+  );
+  const day = date.getUTCDay();
+  const diff = day === 0 ? 6 : 6 - day;
+  date.setUTCDate(date.getUTCDate() + diff);
+  date.setUTCHours(23, 59, 59, 999);
+  return date;
+}
+
+function isValidEvent(event) {
+  if (!event) return false;
+  const start = parseISODate(event.startsAt);
+  const end = parseISODate(event.endsAt);
+  if (!start || !end) return false;
+  return end >= start;
 }

--- a/app/components/EventCard.js
+++ b/app/components/EventCard.js
@@ -1,0 +1,95 @@
+export function createEventCard({ event, onToggleFavorite, favorite, formatDate }) {
+  const listItem = document.createElement("li");
+  listItem.className = "event-card-item";
+
+  const article = document.createElement("article");
+  article.className = "event-card";
+  article.setAttribute("aria-labelledby", `event-${event.id}-title`);
+
+  if (event.featured) {
+    article.classList.add("is-featured");
+  }
+
+  const header = document.createElement("header");
+  header.className = "event-card__header";
+
+  const title = document.createElement("h3");
+  title.className = "event-card__title";
+  title.id = `event-${event.id}-title`;
+  title.textContent = event.title;
+
+  const favoriteButton = document.createElement("button");
+  favoriteButton.type = "button";
+  favoriteButton.className = "event-card__favorite";
+  favoriteButton.classList.toggle("is-active", Boolean(favorite));
+  favoriteButton.setAttribute("aria-pressed", String(Boolean(favorite)));
+  favoriteButton.setAttribute(
+    "aria-label",
+    favorite ? "Aus Favoriten entfernen" : "Zu Favoriten hinzufügen"
+  );
+  favoriteButton.innerHTML = favorite ? "★" : "☆";
+  favoriteButton.addEventListener("click", () => {
+    onToggleFavorite?.();
+    const isFav = !favoriteButton.classList.contains("is-active");
+    favoriteButton.classList.toggle("is-active", isFav);
+    favoriteButton.setAttribute("aria-pressed", String(isFav));
+    favoriteButton.innerHTML = isFav ? "★" : "☆";
+    favoriteButton.setAttribute(
+      "aria-label",
+      isFav ? "Aus Favoriten entfernen" : "Zu Favoriten hinzufügen"
+    );
+  });
+
+  header.append(title, favoriteButton);
+
+  if (event.image) {
+    const figure = document.createElement("figure");
+    figure.className = "event-card__media";
+
+    const img = document.createElement("img");
+    img.src = event.image;
+    img.alt = event.title;
+    img.loading = "lazy";
+    figure.appendChild(img);
+
+    article.appendChild(figure);
+  }
+
+  const timeInfo = document.createElement("p");
+  timeInfo.className = "event-card__time";
+  timeInfo.textContent = `${formatDate(event.startsAt)} – ${formatDate(event.endsAt)}`;
+
+  const locationInfo = document.createElement("p");
+  locationInfo.className = "event-card__location";
+  locationInfo.textContent = event.location || "VRChat";
+
+  article.append(header, timeInfo, locationInfo);
+
+  if (Array.isArray(event.tags) && event.tags.length > 0) {
+    const tagList = document.createElement("ul");
+    tagList.className = "event-card__tags";
+    tagList.setAttribute("role", "list");
+    event.tags.forEach((tag) => {
+      const tagItem = document.createElement("li");
+      tagItem.textContent = tag;
+      tagList.appendChild(tagItem);
+    });
+    article.appendChild(tagList);
+  }
+
+  const footer = document.createElement("footer");
+  footer.className = "event-card__footer";
+
+  const link = document.createElement("a");
+  link.href = event.vrchatUrl;
+  link.target = "_blank";
+  link.rel = "noopener noreferrer";
+  link.textContent = "Event öffnen";
+  link.className = "event-card__link";
+
+  footer.appendChild(link);
+  article.appendChild(footer);
+
+  listItem.appendChild(article);
+  return listItem;
+}

--- a/app/components/Skeleton.js
+++ b/app/components/Skeleton.js
@@ -1,0 +1,30 @@
+export function createSkeletonList({ count = 3, variant = "event" } = {}) {
+  const container = document.createElement("ul");
+  container.className = `skeleton-list skeleton-${variant}`;
+  container.setAttribute("role", "list");
+  for (let index = 0; index < count; index += 1) {
+    container.appendChild(createSkeletonCard({ variant }));
+  }
+  return container;
+}
+
+export function createSkeletonCard({ variant = "event" } = {}) {
+  const listItem = document.createElement("li");
+  listItem.className = `skeleton-card skeleton-${variant}-card`;
+
+  const block = document.createElement("div");
+  block.className = "skeleton-block";
+
+  const line1 = document.createElement("div");
+  line1.className = "skeleton-line skeleton-line--title";
+
+  const line2 = document.createElement("div");
+  line2.className = "skeleton-line skeleton-line--subtitle";
+
+  const line3 = document.createElement("div");
+  line3.className = "skeleton-line skeleton-line--meta";
+
+  block.append(line1, line2, line3);
+  listItem.appendChild(block);
+  return listItem;
+}

--- a/app/state/favorites.js
+++ b/app/state/favorites.js
@@ -1,0 +1,63 @@
+const STORAGE_KEY = "hub:fav:v1";
+const listeners = new Set();
+
+export function getFavorites() {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (!stored) return new Set();
+    const parsed = JSON.parse(stored);
+    if (!Array.isArray(parsed)) return new Set();
+    return new Set(parsed);
+  } catch (error) {
+    console.warn("Favoriten konnten nicht gelesen werden", error);
+    return new Set();
+  }
+}
+
+export function setFavorites(favorites) {
+  try {
+    const ids = Array.from(favorites);
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(ids));
+    emitChange(new Set(ids));
+  } catch (error) {
+    console.warn("Favoriten konnten nicht gespeichert werden", error);
+  }
+}
+
+export function toggleFavorite(id) {
+  const favorites = getFavorites();
+  if (favorites.has(id)) {
+    favorites.delete(id);
+  } else {
+    favorites.add(id);
+  }
+  setFavorites(favorites);
+}
+
+export function isFavorite(id) {
+  return getFavorites().has(id);
+}
+
+export function onFavoritesChange(callback) {
+  if (typeof callback !== "function") {
+    return () => {};
+  }
+  listeners.add(callback);
+  return () => {
+    listeners.delete(callback);
+  };
+}
+
+export function listFavorites() {
+  return Array.from(getFavorites());
+}
+
+function emitChange(favorites) {
+  listeners.forEach((listener) => {
+    try {
+      listener(favorites);
+    } catch (error) {
+      console.error("Fehler im Favoriten-Listener", error);
+    }
+  });
+}

--- a/app/utils/date.js
+++ b/app/utils/date.js
@@ -1,0 +1,78 @@
+export function parseISODate(value) {
+  if (typeof value !== "string") return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return new Date(
+    Date.UTC(
+      date.getUTCFullYear(),
+      date.getUTCMonth(),
+      date.getUTCDate(),
+      date.getUTCHours(),
+      date.getUTCMinutes(),
+      date.getUTCSeconds(),
+      date.getUTCMilliseconds()
+    )
+  );
+}
+
+export function formatDateTime(value) {
+  const date = typeof value === "string" ? parseISODate(value) : value;
+  if (!date) return "";
+  return new Intl.DateTimeFormat("de-DE", {
+    timeZone: "UTC",
+    weekday: "short",
+    day: "2-digit",
+    month: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit"
+  }).format(date);
+}
+
+export function isToday(date) {
+  if (!(date instanceof Date)) return false;
+  const now = new Date();
+  return (
+    date.getUTCFullYear() === now.getUTCFullYear() &&
+    date.getUTCMonth() === now.getUTCMonth() &&
+    date.getUTCDate() === now.getUTCDate()
+  );
+}
+
+export function isThisWeek(date) {
+  if (!(date instanceof Date)) return false;
+  const now = new Date();
+  const startOfWeek = getStartOfWeek(now);
+  const endOfWeek = getEndOfWeek(now);
+  return date >= startOfWeek && date <= endOfWeek;
+}
+
+export function compareAsc(a, b) {
+  if (!(a instanceof Date) || !(b instanceof Date)) return 0;
+  if (a < b) return -1;
+  if (a > b) return 1;
+  return 0;
+}
+
+export function toISODate(date) {
+  if (!(date instanceof Date)) return "";
+  return date.toISOString();
+}
+
+function getStartOfWeek(baseDate) {
+  const date = new Date(
+    Date.UTC(baseDate.getUTCFullYear(), baseDate.getUTCMonth(), baseDate.getUTCDate())
+  );
+  const day = date.getUTCDay();
+  const diff = day === 0 ? -6 : 1 - day;
+  date.setUTCDate(date.getUTCDate() + diff);
+  date.setUTCHours(0, 0, 0, 0);
+  return date;
+}
+
+function getEndOfWeek(baseDate) {
+  const start = getStartOfWeek(baseDate);
+  const end = new Date(start);
+  end.setUTCDate(start.getUTCDate() + 6);
+  end.setUTCHours(23, 59, 59, 999);
+  return end;
+}

--- a/data/events.sample.json
+++ b/data/events.sample.json
@@ -1,0 +1,80 @@
+[
+  {
+    "id": "event-001",
+    "title": "Community Kickoff Gathering",
+    "startsAt": "2024-05-30T18:00:00Z",
+    "endsAt": "2024-05-30T20:00:00Z",
+    "location": "VRChat Plaza",
+    "vrchatUrl": "https://vrchat.com/home/world/wrld_001",
+    "image": "./media/images/event-001.jpg",
+    "tags": ["Networking", "Deutsch"],
+    "featured": true,
+    "updatedAt": "2024-05-01T09:00:00Z",
+    "createdAt": "2024-04-15T10:30:00Z"
+  },
+  {
+    "id": "event-002",
+    "title": "Creator Workshop: Lighting Basics",
+    "startsAt": "2024-06-02T17:00:00Z",
+    "endsAt": "2024-06-02T19:00:00Z",
+    "location": "Studio Lounge",
+    "vrchatUrl": "https://vrchat.com/home/world/wrld_002",
+    "image": "./media/images/event-002.jpg",
+    "tags": ["Workshop", "Creative"],
+    "featured": false,
+    "updatedAt": "2024-05-05T10:00:00Z",
+    "createdAt": "2024-04-20T11:45:00Z"
+  },
+  {
+    "id": "event-003",
+    "title": "Speed Networking Night",
+    "startsAt": "2024-06-05T20:00:00Z",
+    "endsAt": "2024-06-05T21:30:00Z",
+    "location": "Hyper Club",
+    "vrchatUrl": "https://vrchat.com/home/world/wrld_003",
+    "image": "./media/images/event-003.jpg",
+    "tags": ["Networking", "English"],
+    "featured": true,
+    "updatedAt": "2024-05-07T11:00:00Z",
+    "createdAt": "2024-04-21T09:00:00Z"
+  },
+  {
+    "id": "event-004",
+    "title": "World Builders Meetup",
+    "startsAt": "2024-06-08T16:00:00Z",
+    "endsAt": "2024-06-08T18:30:00Z",
+    "location": "Builder's Bay",
+    "vrchatUrl": "https://vrchat.com/home/world/wrld_004",
+    "image": "./media/images/event-004.jpg",
+    "tags": ["Builders", "Collaboration"],
+    "featured": false,
+    "updatedAt": "2024-05-10T12:00:00Z",
+    "createdAt": "2024-04-25T13:20:00Z"
+  },
+  {
+    "id": "event-005",
+    "title": "Community Game Night",
+    "startsAt": "2024-06-12T19:00:00Z",
+    "endsAt": "2024-06-12T21:30:00Z",
+    "location": "Arcade Hub",
+    "vrchatUrl": "https://vrchat.com/home/world/wrld_005",
+    "image": "./media/images/event-005.jpg",
+    "tags": ["Games", "Fun"],
+    "featured": false,
+    "updatedAt": "2024-05-12T09:45:00Z",
+    "createdAt": "2024-04-28T15:00:00Z"
+  },
+  {
+    "id": "event-006",
+    "title": "Community Retrospective",
+    "startsAt": "2024-06-18T18:30:00Z",
+    "endsAt": "2024-06-18T20:00:00Z",
+    "location": "Reflection Hall",
+    "vrchatUrl": "https://vrchat.com/home/world/wrld_006",
+    "image": "./media/images/event-006.jpg",
+    "tags": ["Community", "Discussion"],
+    "featured": false,
+    "updatedAt": "2024-05-14T10:10:00Z",
+    "createdAt": "2024-05-01T09:30:00Z"
+  }
+]

--- a/data/news.sample.json
+++ b/data/news.sample.json
@@ -1,0 +1,42 @@
+[
+  {
+    "id": "news-001",
+    "title": "Neue Community-Guidelines veröffentlicht",
+    "body": "Die aktualisierten Guidelines legen besonderen Fokus auf respektvolles Miteinander in VR.",
+    "url": "https://communityhub.example.com/news/guidelines",
+    "publishedAt": "2024-05-20T08:00:00Z",
+    "updatedAt": "2024-05-20T08:00:00Z"
+  },
+  {
+    "id": "news-002",
+    "title": "Event-Reihe: Creator Spotlight",
+    "body": "Jeden Mittwoch stellen wir die spannendsten Creator und ihre Welten vor.",
+    "url": "https://communityhub.example.com/news/creator-spotlight",
+    "publishedAt": "2024-05-22T10:30:00Z",
+    "updatedAt": "2024-05-22T10:30:00Z"
+  },
+  {
+    "id": "news-003",
+    "title": "Beta-Test für neues Hub-Feature",
+    "body": "Teste als Erste*r unser neues Favoriten-System und gib Feedback.",
+    "url": "https://communityhub.example.com/news/beta-favorites",
+    "publishedAt": "2024-05-24T09:15:00Z",
+    "updatedAt": "2024-05-24T11:00:00Z"
+  },
+  {
+    "id": "news-004",
+    "title": "Community Highlight: VR Art Gallery",
+    "body": "Erkunde die neu kuratierte Kunstgalerie im VRChat Community Hub.",
+    "url": "https://communityhub.example.com/news/vr-art-gallery",
+    "publishedAt": "2024-05-26T12:00:00Z",
+    "updatedAt": "2024-05-26T12:00:00Z"
+  },
+  {
+    "id": "news-005",
+    "title": "Rückblick: Workshop Lighting Basics",
+    "body": "Danke an alle Teilnehmer*innen – hier sind die wichtigsten Erkenntnisse und Links.",
+    "url": "https://communityhub.example.com/news/workshop-recap",
+    "publishedAt": "2024-05-28T14:45:00Z",
+    "updatedAt": "2024-05-28T15:00:00Z"
+  }
+]

--- a/media/schemas/events.schema.json
+++ b/media/schemas/events.schema.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Events Schema",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "required": [
+      "id",
+      "title",
+      "startsAt",
+      "endsAt",
+      "location",
+      "vrchatUrl",
+      "image",
+      "tags",
+      "featured",
+      "updatedAt",
+      "createdAt"
+    ],
+    "properties": {
+      "id": {
+        "type": "string"
+      },
+      "title": {
+        "type": "string"
+      },
+      "startsAt": {
+        "type": "string",
+        "format": "date-time"
+      },
+      "endsAt": {
+        "type": "string",
+        "format": "date-time"
+      },
+      "location": {
+        "type": "string"
+      },
+      "vrchatUrl": {
+        "type": "string"
+      },
+      "image": {
+        "type": "string"
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "featured": {
+        "type": "boolean"
+      },
+      "updatedAt": {
+        "type": "string",
+        "format": "date-time"
+      },
+      "createdAt": {
+        "type": "string",
+        "format": "date-time"
+      }
+    }
+  }
+}

--- a/media/schemas/news.schema.json
+++ b/media/schemas/news.schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "News Schema",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "required": [
+      "id",
+      "title",
+      "body",
+      "url",
+      "publishedAt",
+      "updatedAt"
+    ],
+    "properties": {
+      "id": {
+        "type": "string"
+      },
+      "title": {
+        "type": "string"
+      },
+      "body": {
+        "type": "string"
+      },
+      "url": {
+        "type": "string"
+      },
+      "publishedAt": {
+        "type": "string",
+        "format": "date-time"
+      },
+      "updatedAt": {
+        "type": "string",
+        "format": "date-time"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add JSON schemas for events and news along with sample datasets
- introduce date utilities, skeleton loader, and event card component to support the events experience
- extend the events view with schema validation, stale-while-revalidate fetching, tabbed filtering, favorites, and offline/error handling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e105d3e4f0832bb767d0a79ab45f61